### PR TITLE
DEV-12940 Added filtering for categories.

### DIFF
--- a/bin.ts
+++ b/bin.ts
@@ -53,7 +53,7 @@ while (i < Deno.args.length) {
     case "-o":
     case "--out":
       options.outputFile = Deno.args[i++];
-      if (!options.globbingPattern) {
+      if (!options.outputFile) {
         throw new Error("Output file cannot be empty");
       }
       continue;

--- a/src/replace.ts
+++ b/src/replace.ts
@@ -2,6 +2,7 @@ import { Block, parse } from "https://esm.sh/comment-parser@1.3.0";
 import * as Colors from "https://deno.land/std@0.116.0/fmt/colors.ts";
 import { serializeTag } from "./formatting.ts";
 import {
+  getCategoryTags,
   getConstTags,
   getDeprecatedTags,
   getDescriptionAndRemarksTag,
@@ -44,6 +45,7 @@ export function getTsdocStringForJsdocAst(ast: Block): string {
     ],
     [
       // Then the API shape itself
+      ...getCategoryTags(ast.tags),
       ...getConstTags(ast.tags),
       ...getDoctypeTags(ast.tags),
       ...getExampleTags(ast.tags),

--- a/src/tags.ts
+++ b/src/tags.ts
@@ -10,6 +10,18 @@ import {
 export function getVirtualTags(specs: Spec[]) {
   return serializeTag(specs, "abstract", { tsdocTagName: "virtual" });
 }
+
+export function getCategoryTags(specs: Spec[]) {
+  const categoryTag = specs.filter((spec) => spec.tag === "category");
+  const allowedCategories = ['family/cvk', 'fds/components', 'fds/system', 'widget'];
+
+  if (categoryTag[0] && categoryTag[0].name && allowedCategories.includes(categoryTag[0].name)) {
+    return serializeTag(specs, "category");
+  } else {
+    return []
+  }
+}
+
 export function getConstTags(specs: Spec[]) {
   return serializeTag(specs, "const", { includeTypeInfo: true });
 }

--- a/src/tags.ts
+++ b/src/tags.ts
@@ -13,7 +13,7 @@ export function getVirtualTags(specs: Spec[]) {
 
 export function getCategoryTags(specs: Spec[]) {
   const categoryTag = specs.filter((spec) => spec.tag === "category");
-  const allowedCategories = ['family/cvk', 'fds/components', 'fds/system', 'widget'];
+  const allowedCategories = ['family/cvk', 'fds/components', 'fds/system', 'widget', 'manager'];
 
   if (categoryTag[0] && categoryTag[0].name && allowedCategories.includes(categoryTag[0].name)) {
     return serializeTag(specs, "category");

--- a/test/units/category.test.ts
+++ b/test/units/category.test.ts
@@ -77,3 +77,17 @@ Deno.test("@category family/cvk", () =>
        */
     `,
   ));
+
+  Deno.test("@category manager", () =>
+  assertEquals(
+    jsdoc`
+      /**
+       * @category manager
+       */
+    `,
+    tsdoc`
+      /**
+       * @category manager
+       */
+    `,
+  ));

--- a/test/units/category.test.ts
+++ b/test/units/category.test.ts
@@ -20,3 +20,60 @@ Deno.test("@category and description", () =>
     `,
     tsdoc``,
   ));
+
+Deno.test("@category family/cvk", () =>
+  assertEquals(
+    jsdoc`
+      /**
+       * @category family/cvk
+       */
+    `,
+    tsdoc`
+      /**
+       * @category family/cvk
+       */
+    `,
+  ));
+
+
+  Deno.test("@category fds/components", () =>
+  assertEquals(
+    jsdoc`
+      /**
+       * @category fds/components
+       */
+    `,
+    tsdoc`
+      /**
+       * @category fds/components
+       */
+    `,
+  ));
+
+  Deno.test("@category fds/system", () =>
+  assertEquals(
+    jsdoc`
+      /**
+       * @category fds/system
+       */
+    `,
+    tsdoc`
+      /**
+       * @category fds/system
+       */
+    `,
+  ));
+
+  Deno.test("@category widget", () =>
+  assertEquals(
+    jsdoc`
+      /**
+       * @category widget
+       */
+    `,
+    tsdoc`
+      /**
+       * @category widget
+       */
+    `,
+  ));


### PR DESCRIPTION
Added filtering for @category. All @category tags are removed, except the following ones:
@category family/cvk       --> CVK families
@category fds/components   --> Design system components
@category fds/system       --> Design system utilities
@category widget           --> CVK widgets
@category manager          --> Managers